### PR TITLE
EC-1700: Add bundle auto-detection to Rego sigstore builtins

### DIFF
--- a/acceptance/image/image.go
+++ b/acceptance/image/image.go
@@ -1197,12 +1197,14 @@ func AttestationSignaturesFrom(ctx context.Context, prefix string) (map[string]s
 	state := testenv.FetchState[imageState](ctx)
 
 	signatures := map[string]string{}
-	for name, signature := range state.AttestationSignatures {
-		if signature.KeyID != "" {
-			signatures[fmt.Sprintf("%s_KEY_ID_%s", prefix, name)] = signature.KeyID
-		}
-		if signature.Signature != "" {
-			signatures[fmt.Sprintf("%s_%s", prefix, name)] = signature.Signature
+	for _, m := range []map[string]Signature{state.AttestationSignatures, state.ReferrerAttestationSignatures} {
+		for name, signature := range m {
+			if signature.KeyID != "" {
+				signatures[fmt.Sprintf("%s_KEY_ID_%s", prefix, name)] = signature.KeyID
+			}
+			if signature.Signature != "" {
+				signatures[fmt.Sprintf("%s_%s", prefix, name)] = signature.Signature
+			}
 		}
 	}
 
@@ -1217,8 +1219,10 @@ func RawAttestationSignaturesFrom(ctx context.Context) map[string]string {
 	state := testenv.FetchState[imageState](ctx)
 
 	ret := map[string]string{}
-	for ref, signature := range state.AttestationSignatures {
-		ret[fmt.Sprintf("ATTESTATION_SIGNATURE_%s", ref)] = signature.Signature
+	for _, m := range []map[string]Signature{state.AttestationSignatures, state.ReferrerAttestationSignatures} {
+		for ref, signature := range m {
+			ret[fmt.Sprintf("ATTESTATION_SIGNATURE_%s", ref)] = signature.Signature
+		}
 	}
 
 	return ret
@@ -1232,12 +1236,14 @@ func ImageSignaturesFrom(ctx context.Context, prefix string) (map[string]string,
 	state := testenv.FetchState[imageState](ctx)
 
 	ret := map[string]string{}
-	for name, signature := range state.ImageSignatures {
-		if signature.KeyID != "" {
-			ret[fmt.Sprintf("%s_KEY_ID_%s", prefix, name)] = signature.KeyID
-		}
-		if signature.Signature != "" {
-			ret[fmt.Sprintf("%s_%s", prefix, name)] = signature.Signature
+	for _, m := range []map[string]Signature{state.ImageSignatures, state.ReferrerImageSignatures} {
+		for name, signature := range m {
+			if signature.KeyID != "" {
+				ret[fmt.Sprintf("%s_KEY_ID_%s", prefix, name)] = signature.KeyID
+			}
+			if signature.Signature != "" {
+				ret[fmt.Sprintf("%s_%s", prefix, name)] = signature.Signature
+			}
 		}
 	}
 
@@ -1252,8 +1258,10 @@ func RawImageSignaturesFrom(ctx context.Context) map[string]string {
 	state := testenv.FetchState[imageState](ctx)
 
 	ret := map[string]string{}
-	for ref, signature := range state.ImageSignatures {
-		ret[fmt.Sprintf("IMAGE_SIGNATURE_%s", ref)] = signature.Signature
+	for _, m := range []map[string]Signature{state.ImageSignatures, state.ReferrerImageSignatures} {
+		for ref, signature := range m {
+			ret[fmt.Sprintf("IMAGE_SIGNATURE_%s", ref)] = signature.Signature
+		}
 	}
 
 	return ret

--- a/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
+++ b/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
@@ -32,7 +32,6 @@ import (
 	"github.com/santhosh-tekuri/jsonschema/v5"
 	"github.com/sigstore/cosign/v3/pkg/cosign"
 	cosignOCI "github.com/sigstore/cosign/v3/pkg/oci"
-	ociremote "github.com/sigstore/cosign/v3/pkg/oci/remote"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 
@@ -123,9 +122,8 @@ func (a *ApplicationSnapshotImage) SetImageURL(url string) error {
 }
 
 func (a *ApplicationSnapshotImage) hasBundles(ctx context.Context) bool {
-	regOpts := []ociremote.Option{ociremote.WithRemoteOptions(oci.CreateRemoteOptions(ctx)...)}
-	bundles, _, err := cosign.GetBundles(ctx, a.reference, regOpts)
-	return err == nil && len(bundles) > 0
+	found, err := oci.NewClient(ctx).HasBundles(ctx, a.reference)
+	return err == nil && found
 }
 
 func (a *ApplicationSnapshotImage) FetchImageConfig(ctx context.Context) error {

--- a/internal/evaluation_target/application_snapshot_image/application_snapshot_image_test.go
+++ b/internal/evaluation_target/application_snapshot_image/application_snapshot_image_test.go
@@ -476,12 +476,13 @@ func TestValidateImageSignatureClaims(t *testing.T) {
 
 	ctx := o.WithClient(context.Background(), &c)
 
+	c.On("HasBundles", mock.Anything, ref).Return(false, nil)
 	c.On("VerifyImageSignatures", ref, mock.Anything).Return([]oci.Signature{}, false, nil)
 
 	err := a.ValidateImageSignature(ctx)
 	require.NoError(t, err)
 
-	call := c.Calls[0]
+	call := c.Calls[1]
 
 	checkOpts := call.Arguments.Get(1).(*cosign.CheckOpts)
 	assert.NotNil(t, checkOpts)
@@ -597,12 +598,13 @@ func TestValidateAttestationSignatureClaims(t *testing.T) {
 
 	ctx := o.WithClient(context.Background(), &c)
 
+	c.On("HasBundles", mock.Anything, ref).Return(false, nil)
 	c.On("VerifyImageAttestations", ref, mock.Anything).Return([]oci.Signature{}, false, nil)
 
 	err := a.ValidateAttestationSignature(ctx)
 	require.NoError(t, err)
 
-	call := c.Calls[0]
+	call := c.Calls[1]
 
 	checkOpts := call.Arguments.Get(1).(*cosign.CheckOpts)
 	assert.NotNil(t, checkOpts)
@@ -739,6 +741,7 @@ func TestValidateImageSignatureWithCertificates(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	c.On("HasBundles", mock.Anything, ref).Return(false, nil)
 	c.On("VerifyImageSignatures", ref, mock.Anything).Return([]oci.Signature{sig}, false, nil)
 
 	err = a.ValidateImageSignature(ctx)
@@ -1339,6 +1342,7 @@ func TestValidateAttestationSignature(t *testing.T) {
 			a := ApplicationSnapshotImage{reference: ref}
 
 			client := fake.FakeClient{}
+			client.On("HasBundles", mock.Anything, ref).Return(false, nil)
 			client.On("VerifyImageAttestations", ref, mock.Anything).Return(tc.signatures, false, tc.verifyErr)
 
 			ctx := o.WithClient(context.Background(), &client)

--- a/internal/image/validate_test.go
+++ b/internal/image/validate_test.go
@@ -80,6 +80,7 @@ func TestBuiltinChecks(t *testing.T) {
 			name: "simple success",
 			setup: func(c *fake.FakeClient) {
 				c.On("Head", ref).Return(&v1.Descriptor{MediaType: types.OCIManifestSchema1}, nil)
+				c.On("HasBundles", mock.Anything, refNoTag).Return(false, nil)
 				c.On("VerifyImageSignatures", refNoTag, mock.Anything).Return([]oci.Signature{validSignature}, true, nil)
 				c.On("VerifyImageAttestations", refNoTag, mock.Anything).Return([]oci.Signature{validAttestation}, true, nil)
 			},
@@ -106,6 +107,7 @@ func TestBuiltinChecks(t *testing.T) {
 			name: "no image signatures",
 			setup: func(c *fake.FakeClient) {
 				c.On("Head", ref).Return(&v1.Descriptor{MediaType: types.OCIManifestSchema1}, nil)
+				c.On("HasBundles", mock.Anything, refNoTag).Return(false, nil)
 				c.On("VerifyImageSignatures", refNoTag, mock.Anything).Return(nil, false, errors.New("no image signatures client error"))
 				c.On("VerifyImageAttestations", refNoTag, mock.Anything).Return([]oci.Signature{validAttestation}, true, nil)
 			},
@@ -122,6 +124,7 @@ func TestBuiltinChecks(t *testing.T) {
 			name: "no image attestations",
 			setup: func(c *fake.FakeClient) {
 				c.On("Head", ref).Return(&v1.Descriptor{MediaType: types.OCIManifestSchema1}, nil)
+				c.On("HasBundles", mock.Anything, refNoTag).Return(false, nil)
 				c.On("VerifyImageSignatures", refNoTag, mock.Anything).Return(validSignature, true, nil)
 				c.On("VerifyImageAttestations", refNoTag, mock.Anything).Return(nil, false, errors.New("no image attestations client error"))
 			},
@@ -325,6 +328,7 @@ func TestEvaluatorLifecycle(t *testing.T) {
 	ctx = ecoci.WithClient(ctx, &client)
 	client.On("Image", name.MustParseReference(imageRegistry+"@sha256:"+imageDigest), mock.Anything).Return(empty.Image, nil)
 	client.On("Head", ref).Return(&v1.Descriptor{MediaType: types.OCIManifestSchema1}, nil)
+	client.On("HasBundles", mock.Anything, refNoTag).Return(false, nil)
 	client.On("VerifyImageSignatures", refNoTag, mock.Anything).Return([]oci.Signature{validSignature}, true, nil)
 	client.On("VerifyImageAttestations", refNoTag, mock.Anything).Return([]oci.Signature{validAttestation}, true, nil)
 	client.On("ResolveDigest", refNoTag).Return("@sha256:"+imageDigest, nil)
@@ -367,6 +371,7 @@ func TestComponentNamePassedToEvaluator(t *testing.T) {
 	client := fake.FakeClient{}
 	client.On("Head", mock.Anything).Return(&v1.Descriptor{MediaType: types.OCIManifestSchema1}, nil)
 	client.On("Image", name.MustParseReference(imageRegistry+"@sha256:"+imageDigest), mock.Anything).Return(empty.Image, nil)
+	client.On("HasBundles", mock.Anything, refNoTag).Return(false, nil)
 	client.On("VerifyImageSignatures", refNoTag, mock.Anything).Return([]oci.Signature{validSignature}, true, nil)
 	client.On("VerifyImageAttestations", refNoTag, mock.Anything).Return([]oci.Signature{validAttestation}, true, nil)
 	client.On("ResolveDigest", refNoTag).Return("@sha256:"+imageDigest, nil)
@@ -609,6 +614,7 @@ func TestValidateImageSkipImageSigCheck(t *testing.T) {
 			// Set up minimal fake data for image to pass accessibility check
 			// and signature/attestation checks (they will fail but create results)
 			fakeClient.On("Head", ref).Return(&v1.Descriptor{MediaType: types.OCIManifestSchema1}, nil)
+			fakeClient.On("HasBundles", mock.Anything, refNoTag).Return(false, nil)
 			fakeClient.On("VerifyImageSignatures", refNoTag, mock.Anything).Return([]oci.Signature{}, false, fmt.Errorf("no signatures found"))
 			fakeClient.On("VerifyImageAttestations", refNoTag, mock.Anything).Return([]oci.Signature{}, false, fmt.Errorf("no attestations found"))
 

--- a/internal/rego/sigstore/sigstore.go
+++ b/internal/rego/sigstore/sigstore.go
@@ -131,10 +131,25 @@ func sigstoreVerifyImage(bctx rego.BuiltinContext, refTerm *ast.Term, optsTerm *
 		logger.WithField("error", err).Debug("failed to parse check opts")
 		return signatureFailedResult(fmt.Errorf("opts parameter: %w", err))
 	}
-	checkOpts.ClaimVerifier = cosign.SimpleClaimVerifier
 
-	logger.Debug("verifying image signatures")
-	signatures, _, err := ecoci.NewClient(ctx).VerifyImageSignatures(ref, checkOpts)
+	client := ecoci.NewClient(ctx)
+	useBundles, err := client.HasBundles(ctx, ref)
+	if err != nil {
+		logger.WithField("error", err).Debug("bundle detection failed, falling back to legacy path")
+		useBundles = false
+	}
+
+	var signatures []oci.Signature
+	if useBundles {
+		logger.Debug("bundles detected, using bundle verification path")
+		checkOpts.NewBundleFormat = true
+		checkOpts.ClaimVerifier = cosign.IntotoSubjectClaimVerifier
+		signatures, _, err = client.VerifyImageAttestations(ref, checkOpts)
+	} else {
+		checkOpts.ClaimVerifier = cosign.SimpleClaimVerifier
+		logger.Debug("verifying image signatures")
+		signatures, _, err = client.VerifyImageSignatures(ref, checkOpts)
+	}
 	if err != nil {
 		logger.WithField("error", err).Debug("failed to verify image signature")
 		return signatureFailedResult(fmt.Errorf("verify image signature: %w", err))
@@ -202,15 +217,26 @@ func sigstoreVerifyAttestation(bctx rego.BuiltinContext, refTerm *ast.Term, opts
 	}
 	checkOpts.ClaimVerifier = cosign.IntotoSubjectClaimVerifier
 
+	client := ecoci.NewClient(ctx)
+	useBundles, err := client.HasBundles(ctx, ref)
+	if err != nil {
+		logger.WithField("error", err).Debug("bundle detection failed, falling back to legacy path")
+		useBundles = false
+	}
+	if useBundles {
+		logger.Debug("bundles detected, using bundle verification path")
+		checkOpts.NewBundleFormat = true
+	}
+
 	logger.Debug("verifying image attestations")
-	attestations, _, err := ecoci.NewClient(ctx).VerifyImageAttestations(ref, checkOpts)
+	attestations, _, err := client.VerifyImageAttestations(ref, checkOpts)
 	if err != nil {
 		logger.WithField("error", err).Debug("failed to verify image attestation signature")
 		return attestationFailedResult(fmt.Errorf("verify image attestation signature: %w", err))
 	}
 
 	logger.WithField("attestations_count", len(attestations)).Debug("attestation verification complete")
-	return attestationResult(attestations, nil)
+	return attestationResult(attestations, useBundles, nil)
 }
 
 func parseCheckOpts(ctx context.Context, optsTerm *ast.Term) (*cosign.CheckOpts, error) {
@@ -340,10 +366,10 @@ func signatureResult(signatures []oci.Signature, err error) (*ast.Term, error) {
 }
 
 func attestationFailedResult(err error) (*ast.Term, error) {
-	return attestationResult(nil, err)
+	return attestationResult(nil, false, err)
 }
 
-func attestationResult(attestations []oci.Signature, err error) (*ast.Term, error) {
+func attestationResult(attestations []oci.Signature, useBundles bool, err error) (*ast.Term, error) {
 	var errorTerms []*ast.Term
 	var attestationTerms []*ast.Term
 
@@ -352,9 +378,33 @@ func attestationResult(attestations []oci.Signature, err error) (*ast.Term, erro
 	}
 
 	for _, s := range attestations {
-		att, err := attestation.ProvenanceFromSignature(s)
-		if err != nil {
-			errorTerms = append(errorTerms, ast.StringTerm(fmt.Sprintf("parsing attestation: %s", err)))
+		var att attestation.Attestation
+		var parseErr error
+
+		if useBundles {
+			payload, pErr := s.Payload()
+			if pErr != nil {
+				log.WithField("error", pErr).Debug("skipping bundle entry: cannot read payload")
+				continue
+			}
+			var dsseEnvelope struct {
+				PayloadType string `json:"payloadType"`
+			}
+			if jErr := json.Unmarshal(payload, &dsseEnvelope); jErr != nil {
+				log.WithField("error", jErr).Debug("skipping bundle entry: not a valid DSSE envelope")
+				continue
+			}
+			if dsseEnvelope.PayloadType != "application/vnd.in-toto+json" {
+				log.WithField("payloadType", dsseEnvelope.PayloadType).Debug("skipping bundle entry with non-in-toto payloadType")
+				continue
+			}
+			att, parseErr = attestation.ProvenanceFromBundlePayload(s, payload)
+		} else {
+			att, parseErr = attestation.ProvenanceFromSignature(s)
+		}
+
+		if parseErr != nil {
+			errorTerms = append(errorTerms, ast.StringTerm(fmt.Sprintf("parsing attestation: %s", parseErr)))
 			continue
 		}
 

--- a/internal/rego/sigstore/sigstore_test.go
+++ b/internal/rego/sigstore/sigstore_test.go
@@ -21,6 +21,7 @@ package sigstore
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -189,6 +190,7 @@ func TestSigstoreVerifyImage(t *testing.T) {
 			)
 			require.NoError(t, err)
 
+			c.On("HasBundles", mock.Anything, goodImage).Return(false, nil)
 			verifyCall := c.On(
 				"VerifyImageSignatures", goodImage, mock.Anything,
 			).Return([]oci.Signature{sig}, false, tt.sigError)
@@ -378,6 +380,7 @@ func TestSigstoreVerifyAttestation(t *testing.T) {
 			c := fake.FakeClient{}
 			ctx := o.WithClient(context.Background(), &c)
 
+			c.On("HasBundles", mock.Anything, goodImage).Return(false, nil)
 			verifyCall := c.On(
 				"VerifyImageAttestations", goodImage, mock.Anything,
 			).Return(tt.sigs, false, tt.sigError)
@@ -393,6 +396,294 @@ func TestSigstoreVerifyAttestation(t *testing.T) {
 			require.NotNil(t, result)
 			require.Equal(t, tt.errors, result.Get(ast.StringTerm("errors")))
 			require.Equal(t, tt.success, result.Get(ast.StringTerm("success")))
+		})
+	}
+}
+
+// bundleDSSEPayload creates a DSSE envelope JSON for bundle-format attestations.
+func bundleDSSEPayload(payloadType string, statement any) []byte {
+	statementBytes, err := json.Marshal(statement)
+	if err != nil {
+		panic(err)
+	}
+	envelope := map[string]string{
+		"payloadType": payloadType,
+		"payload":     base64.StdEncoding.EncodeToString(statementBytes),
+	}
+	data, err := json.Marshal(envelope)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
+func TestSigstoreVerifyAttestationWithBundles(t *testing.T) {
+	goodImage := name.MustParseReference(
+		"registry.local/spam@sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb",
+	)
+
+	// Valid in-toto statement for bundle path
+	statement := map[string]any{
+		"_type":         "https://in-toto.io/Statement/v0.1",
+		"predicateType": "https://slsa.dev/provenance/v0.2",
+		"subject":       []any{},
+		"predicate":     map[string]any{},
+	}
+
+	validBundlePayload := bundleDSSEPayload("application/vnd.in-toto+json", statement)
+	validBundleSig, err := static.NewSignature(
+		validBundlePayload,
+		"signature",
+		static.WithLayerMediaType(types.MediaType(cosignTypes.DssePayloadType)),
+	)
+	require.NoError(t, err)
+
+	// Valid DSSE envelope structure but with corrupted base64 payload data
+	malformedBundlePayload := []byte(`{"payloadType":"application/vnd.in-toto+json","payload":"!!!bad-base64!!!"}`)
+	malformedBundleSig, err := static.NewSignature(
+		malformedBundlePayload,
+		"signature",
+		static.WithLayerMediaType(types.MediaType(cosignTypes.DssePayloadType)),
+	)
+	require.NoError(t, err)
+
+	nonInTotoPayload := bundleDSSEPayload("application/octet-stream", "binary-data")
+	nonInTotoSig, err := static.NewSignature(
+		nonInTotoPayload,
+		"signature",
+		static.WithLayerMediaType(types.MediaType(cosignTypes.DssePayloadType)),
+	)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name    string
+		success *ast.Term
+		errors  *ast.Term
+		sigs    []oci.Signature
+	}{
+		{
+			name:    "bundle attestation verification succeeds",
+			success: ast.BooleanTerm(true),
+			errors:  ast.ArrayTerm(),
+			sigs:    []oci.Signature{validBundleSig},
+		},
+		{
+			name:    "malformed bundle payload produces parsing error",
+			success: ast.BooleanTerm(false),
+			errors: ast.ArrayTerm(
+				ast.StringTerm("parsing attestation: malformed attestation data: illegal base64 data at input byte 0"),
+			),
+			sigs: []oci.Signature{malformedBundleSig},
+		},
+		{
+			name:    "non-in-toto payload type is skipped",
+			success: ast.BooleanTerm(true),
+			errors:  ast.ArrayTerm(),
+			sigs:    []oci.Signature{nonInTotoSig},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			utils.SetTestRekorPublicKey(t)
+			utils.SetTestFulcioRoots(t)
+			utils.SetTestCTLogPublicKey(t)
+
+			c := fake.FakeClient{}
+			ctx := o.WithClient(context.Background(), &c)
+
+			c.On("HasBundles", mock.Anything, goodImage).Return(true, nil)
+			c.On(
+				"VerifyImageAttestations", goodImage, mock.Anything,
+			).Return(tt.sigs, false, nil).Run(func(args mock.Arguments) {
+				checkOpts := args.Get(1).(*cosign.CheckOpts)
+				require.True(t, checkOpts.NewBundleFormat)
+			})
+
+			bctx := rego.BuiltinContext{Context: ctx}
+
+			result, err := sigstoreVerifyAttestation(
+				bctx,
+				ast.StringTerm(goodImage.String()),
+				options{ignoreRekor: true, publicKey: utils.TestPublicKey}.toTerm(),
+			)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, tt.errors, result.Get(ast.StringTerm("errors")))
+			require.Equal(t, tt.success, result.Get(ast.StringTerm("success")))
+		})
+	}
+}
+
+func TestSigstoreVerifyAttestationBundleFallback(t *testing.T) {
+	goodImage := name.MustParseReference(
+		"registry.local/spam@sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb",
+	)
+
+	// Legacy-format signature (same as existing tests)
+	goodSig, err := static.NewSignature(
+		[]byte(fmt.Sprintf(`{"payload": "%s"}`, base64.StdEncoding.EncodeToString([]byte("{}")))),
+		"signature",
+		static.WithLayerMediaType(types.MediaType(cosignTypes.DssePayloadType)),
+	)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name       string
+		hasBundles bool
+		bundleErr  error
+	}{
+		{
+			name:       "HasBundles returns error falls back to legacy",
+			hasBundles: false,
+			bundleErr:  errors.New("registry error"),
+		},
+		{
+			name:       "HasBundles returns false uses legacy path",
+			hasBundles: false,
+			bundleErr:  nil,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			utils.SetTestRekorPublicKey(t)
+			utils.SetTestFulcioRoots(t)
+			utils.SetTestCTLogPublicKey(t)
+
+			c := fake.FakeClient{}
+			ctx := o.WithClient(context.Background(), &c)
+
+			c.On("HasBundles", mock.Anything, goodImage).Return(tt.hasBundles, tt.bundleErr)
+			c.On(
+				"VerifyImageAttestations", goodImage, mock.Anything,
+			).Return([]oci.Signature{goodSig}, false, nil)
+
+			bctx := rego.BuiltinContext{Context: ctx}
+
+			result, err := sigstoreVerifyAttestation(
+				bctx,
+				ast.StringTerm(goodImage.String()),
+				options{ignoreRekor: true, publicKey: utils.TestPublicKey}.toTerm(),
+			)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, ast.BooleanTerm(true), result.Get(ast.StringTerm("success")))
+			require.Equal(t, ast.ArrayTerm(), result.Get(ast.StringTerm("errors")))
+		})
+	}
+}
+
+func TestSigstoreVerifyImageWithBundles(t *testing.T) {
+	goodImage := name.MustParseReference(
+		"registry.local/spam@sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb",
+	)
+
+	sig, err := static.NewSignature(
+		[]byte(`image`),
+		"signature",
+		static.WithLayerMediaType(types.MediaType(cosignTypes.DssePayloadType)),
+	)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name    string
+		success *ast.Term
+		errors  *ast.Term
+	}{
+		{
+			name:    "bundle-format image verification succeeds",
+			success: ast.BooleanTerm(true),
+			errors:  ast.ArrayTerm(),
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			utils.SetTestRekorPublicKey(t)
+			utils.SetTestFulcioRoots(t)
+			utils.SetTestCTLogPublicKey(t)
+
+			c := fake.FakeClient{}
+			ctx := o.WithClient(context.Background(), &c)
+
+			c.On("HasBundles", mock.Anything, goodImage).Return(true, nil)
+			c.On(
+				"VerifyImageAttestations", goodImage, mock.Anything,
+			).Return([]oci.Signature{sig}, false, nil).Run(func(args mock.Arguments) {
+				checkOpts := args.Get(1).(*cosign.CheckOpts)
+				require.True(t, checkOpts.NewBundleFormat)
+			})
+
+			bctx := rego.BuiltinContext{Context: ctx}
+
+			result, err := sigstoreVerifyImage(
+				bctx,
+				ast.StringTerm(goodImage.String()),
+				options{ignoreRekor: true, publicKey: utils.TestPublicKey}.toTerm(),
+			)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, tt.errors, result.Get(ast.StringTerm("errors")))
+			require.Equal(t, tt.success, result.Get(ast.StringTerm("success")))
+		})
+	}
+}
+
+func TestSigstoreVerifyImageBundleFallback(t *testing.T) {
+	goodImage := name.MustParseReference(
+		"registry.local/spam@sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb",
+	)
+
+	sig, err := static.NewSignature(
+		[]byte(`image`),
+		"signature",
+		static.WithLayerMediaType(types.MediaType(cosignTypes.DssePayloadType)),
+	)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name       string
+		hasBundles bool
+		bundleErr  error
+	}{
+		{
+			name:       "HasBundles returns error falls back to legacy",
+			hasBundles: false,
+			bundleErr:  errors.New("registry error"),
+		},
+		{
+			name:       "HasBundles returns false uses legacy path",
+			hasBundles: false,
+			bundleErr:  nil,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			utils.SetTestRekorPublicKey(t)
+			utils.SetTestFulcioRoots(t)
+			utils.SetTestCTLogPublicKey(t)
+
+			c := fake.FakeClient{}
+			ctx := o.WithClient(context.Background(), &c)
+
+			c.On("HasBundles", mock.Anything, goodImage).Return(tt.hasBundles, tt.bundleErr)
+			c.On(
+				"VerifyImageSignatures", goodImage, mock.Anything,
+			).Return([]oci.Signature{sig}, false, nil)
+
+			bctx := rego.BuiltinContext{Context: ctx}
+
+			result, err := sigstoreVerifyImage(
+				bctx,
+				ast.StringTerm(goodImage.String()),
+				options{ignoreRekor: true, publicKey: utils.TestPublicKey}.toTerm(),
+			)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, ast.BooleanTerm(true), result.Get(ast.StringTerm("success")))
+			require.Equal(t, ast.ArrayTerm(), result.Get(ast.StringTerm("errors")))
 		})
 	}
 }

--- a/internal/utils/oci/client.go
+++ b/internal/utils/oci/client.go
@@ -76,6 +76,7 @@ func CreateRemoteOptions(ctx context.Context) []remote.Option {
 type Client interface {
 	VerifyImageSignatures(name.Reference, *cosign.CheckOpts) ([]oci.Signature, bool, error)
 	VerifyImageAttestations(name.Reference, *cosign.CheckOpts) ([]oci.Signature, bool, error)
+	HasBundles(context.Context, name.Reference) (bool, error)
 	Head(name.Reference) (*v1.Descriptor, error)
 	ResolveDigest(name.Reference) (string, error)
 	Image(name.Reference) (v1.Image, error)
@@ -127,6 +128,15 @@ func (c *defaultClient) VerifyImageAttestations(ref name.Reference, opts *cosign
 
 	opts.RegistryClientOpts = append(opts.RegistryClientOpts, ociremote.WithRemoteOptions(c.opts...))
 	return cosign.VerifyImageAttestations(c.ctx, ref, opts)
+}
+
+func (c *defaultClient) HasBundles(ctx context.Context, ref name.Reference) (bool, error) {
+	regOpts := []ociremote.Option{ociremote.WithRemoteOptions(c.opts...)}
+	bundles, _, err := cosign.GetBundles(ctx, ref, regOpts)
+	if err != nil {
+		return false, err
+	}
+	return len(bundles) > 0, nil
 }
 
 func (c *defaultClient) Head(ref name.Reference) (*v1.Descriptor, error) {

--- a/internal/utils/oci/fake/client.go
+++ b/internal/utils/oci/fake/client.go
@@ -101,6 +101,11 @@ func (m *FakeClient) VerifyImageAttestations(ref name.Reference, opts *cosign.Ch
 	return sigs, args.Bool(1), args.Error(2)
 }
 
+func (m *FakeClient) HasBundles(ctx context.Context, ref name.Reference) (bool, error) {
+	args := m.Called(ctx, ref)
+	return args.Bool(0), args.Error(1)
+}
+
 func (m *FakeClient) Head(ref name.Reference) (*v1.Descriptor, error) {
 	args := m.Called(ref)
 	var desc *v1.Descriptor


### PR DESCRIPTION
## Summary

- Adds `HasBundles(ctx, ref)` to `oci.Client` interface, wrapping `cosign.GetBundles()` for testable bundle detection
- Auto-detects Sigstore bundles (OCI referrers) in `ec.sigstore.verify_attestation` and `ec.sigstore.verify_image` Rego builtins; when bundles are present, uses `NewBundleFormat=true`, `ProvenanceFromBundlePayload()`, and `IntotoSubjectClaimVerifier`; falls back to legacy `.att` tag-based path when no bundles exist
- Refactors `ApplicationSnapshotImage.hasBundles()` to delegate to the new `oci.Client.HasBundles()` method, eliminating duplication
- Consolidates referrer signatures into acceptance test output maps so snapshot template variables resolve for referrer-format attestations

## Acceptance Criteria

- [x] `verify_attestation` auto-detects bundles via `HasBundles`; sets `NewBundleFormat=true` when present; no new Rego parameter
- [x] `verify_image` auto-detects bundles; uses `NewBundleFormat=true` + `IntotoSubjectClaimVerifier` + `VerifyImageAttestations` when present; legacy uses `SimpleClaimVerifier` + `VerifyImageSignatures`
- [x] `GetBundles` error or empty slice falls back to legacy path without surfacing error
- [x] Bundle path uses `ProvenanceFromBundlePayload()`; legacy uses `ProvenanceFromSignature()`
- [x] Output structure unchanged for both builtins
- [x] Unit tests cover bundle path for `verify_attestation`: valid bundle, malformed bundle
- [x] Unit tests cover bundle path for `verify_image`: successful verification with bundle detection
- [x] Unit tests cover legacy fallback: both builtins behave identically when no bundles
- [x] Bundle detection testable via `Client` interface mock (`FakeClient.HasBundles`)
- [x] Acceptance test verifies end-to-end bundle-format attestation via `CreateAndPushAttestationReferrer` (scenario + snapshot defined locally, not yet pushed -- see note below)
- [x] Non-in-toto `payloadType` entries silently skipped

## Test Plan

- [x] Unit tests pass: `go test -tags=unit ./internal/rego/sigstore/...` (new bundle path + fallback tests)
- [x] Unit tests pass: `go test -tags=unit ./internal/evaluation_target/application_snapshot_image/...` (existing tests with HasBundles mock)
- [x] Unit tests pass: `go test -tags=unit ./internal/image/...` (existing tests with HasBundles mock)
- [x] Build succeeds: `make build`
- [x] `go vet ./...` passes on all changed packages
- [ ] Acceptance test scenario: `sigstore functions with bundle-format attestations` (files not yet pushed from sandbox -- see note)

## Note: Missing acceptance test files

Two acceptance test files could not be pushed from the sandbox due to size constraints with the available push mechanisms (git credential helper not configured, GitHub API auth not injected for REST calls):

- `features/validate_image.feature` (63KB) -- adds scenario \"sigstore functions with bundle-format attestations\" at line 1281
- `features/__snapshots__/validate_image.snap` (150KB) -- adds snapshot block for the new scenario

These files exist on the local branch `EC-1700` and need to be pushed manually. The diff is small: 23 lines inserted in the feature file, 77 lines in the snapshot file.

Ref: https://issues.redhat.com/browse/EC-1700