### PR TITLE
EC-1700: Add bundle auto-detection to Rego sigstore builtins

### DIFF
--- a/acceptance/image/image.go
+++ b/acceptance/image/image.go
@@ -1197,12 +1197,14 @@ func AttestationSignaturesFrom(ctx context.Context, prefix string) (map[string]s
 	state := testenv.FetchState[imageState](ctx)
 
 	signatures := map[string]string{}
-	for name, signature := range state.AttestationSignatures {
-		if signature.KeyID != "" {
-			signatures[fmt.Sprintf("%s_KEY_ID_%s", prefix, name)] = signature.KeyID
-		}
-		if signature.Signature != "" {
-			signatures[fmt.Sprintf("%s_%s", prefix, name)] = signature.Signature
+	for _, m := range []map[string]Signature{state.AttestationSignatures, state.ReferrerAttestationSignatures} {
+		for name, signature := range m {
+			if signature.KeyID != "" {
+				signatures[fmt.Sprintf("%s_KEY_ID_%s", prefix, name)] = signature.KeyID
+			}
+			if signature.Signature != "" {
+				signatures[fmt.Sprintf("%s_%s", prefix, name)] = signature.Signature
+			}
 		}
 	}
 
@@ -1217,8 +1219,10 @@ func RawAttestationSignaturesFrom(ctx context.Context) map[string]string {
 	state := testenv.FetchState[imageState](ctx)
 
 	ret := map[string]string{}
-	for ref, signature := range state.AttestationSignatures {
-		ret[fmt.Sprintf("ATTESTATION_SIGNATURE_%s", ref)] = signature.Signature
+	for _, m := range []map[string]Signature{state.AttestationSignatures, state.ReferrerAttestationSignatures} {
+		for ref, signature := range m {
+			ret[fmt.Sprintf("ATTESTATION_SIGNATURE_%s", ref)] = signature.Signature
+		}
 	}
 
 	return ret
@@ -1232,12 +1236,14 @@ func ImageSignaturesFrom(ctx context.Context, prefix string) (map[string]string,
 	state := testenv.FetchState[imageState](ctx)
 
 	ret := map[string]string{}
-	for name, signature := range state.ImageSignatures {
-		if signature.KeyID != "" {
-			ret[fmt.Sprintf("%s_KEY_ID_%s", prefix, name)] = signature.KeyID
-		}
-		if signature.Signature != "" {
-			ret[fmt.Sprintf("%s_%s", prefix, name)] = signature.Signature
+	for _, m := range []map[string]Signature{state.ImageSignatures, state.ReferrerImageSignatures} {
+		for name, signature := range m {
+			if signature.KeyID != "" {
+				ret[fmt.Sprintf("%s_KEY_ID_%s", prefix, name)] = signature.KeyID
+			}
+			if signature.Signature != "" {
+				ret[fmt.Sprintf("%s_%s", prefix, name)] = signature.Signature
+			}
 		}
 	}
 
@@ -1252,8 +1258,10 @@ func RawImageSignaturesFrom(ctx context.Context) map[string]string {
 	state := testenv.FetchState[imageState](ctx)
 
 	ret := map[string]string{}
-	for ref, signature := range state.ImageSignatures {
-		ret[fmt.Sprintf("IMAGE_SIGNATURE_%s", ref)] = signature.Signature
+	for _, m := range []map[string]Signature{state.ImageSignatures, state.ReferrerImageSignatures} {
+		for ref, signature := range m {
+			ret[fmt.Sprintf("IMAGE_SIGNATURE_%s", ref)] = signature.Signature
+		}
 	}
 
 	return ret

--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -3684,6 +3684,83 @@ Error: success criteria not met
 
 ---
 
+[sigstore functions with bundle-format attestations:stdout - 1]
+{
+  "success": true,
+  "components": [
+    {
+      "name": "Unnamed",
+      "containerImage": "${REGISTRY}/acceptance/sigstore-bundles@sha256:${REGISTRY_acceptance/sigstore-bundles:latest_DIGEST}",
+      "source": {},
+      "successes": [
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "builtin.attestation.signature_check"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "builtin.attestation.syntax_check"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "builtin.image.signature_check"
+          }
+        },
+        {
+          "msg": "Pass",
+          "metadata": {
+            "code": "sigstore.valid"
+          }
+        }
+      ],
+      "success": true,
+      "signatures": [
+        {
+          "keyid": "",
+          "sig": "${IMAGE_SIGNATURE_acceptance/sigstore-bundles}"
+        }
+      ],
+      "attestations": [
+        {
+          "type": "https://in-toto.io/Statement/v0.1",
+          "predicateType": "https://slsa.dev/provenance/v0.2",
+          "predicateBuildType": "https://tekton.dev/attestations/chains/pipelinerun@v2",
+          "signatures": [
+            {
+              "keyid": "",
+              "sig": "${ATTESTATION_SIGNATURE_acceptance/sigstore-bundles}"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "key": "${bundle_PUBLIC_KEY_JSON}",
+  "policy": {
+    "sources": [
+      {
+        "policy": [
+          "git::${GITHOST}/git/sigstore-bundles.git?ref=${LATEST_COMMIT}"
+        ]
+      }
+    ],
+    "rekorUrl": "${REKOR}",
+    "publicKey": "${bundle_PUBLIC_KEY}"
+  },
+  "ec-version": "${EC_VERSION}",
+  "effective-time": "${TIMESTAMP}"
+}
+---
+
+[sigstore functions with bundle-format attestations:stderr - 1]
+
+---
+
 [many components and sources:stdout - 1]
 {
   "success": true,

--- a/features/validate_image.feature
+++ b/features/validate_image.feature
@@ -1278,6 +1278,29 @@ Feature: evaluate enterprise contract
     Then the exit status should be 0
     Then the output should match the snapshot
 
+  Scenario: sigstore functions with bundle-format attestations
+    Given a key pair named "bundle"
+    Given an image named "acceptance/sigstore-bundles"
+    Given a valid image signature referrer of "acceptance/sigstore-bundles" image signed by the "bundle" key
+    Given a valid attestation referrer of "acceptance/sigstore-bundles" signed by the "bundle" key
+    Given a git repository named "sigstore-bundles" with
+      | main.rego | examples/sigstore.rego |
+    Given policy configuration named "ec-policy" with specification
+      """
+      {
+        "sources": [
+          {
+            "policy": [
+              "git::https://${GITHOST}/git/sigstore-bundles.git"
+            ]
+          }
+        ]
+      }
+      """
+    When ec command is run with "validate image --image ${REGISTRY}/acceptance/sigstore-bundles --policy acceptance/ec-policy --public-key ${bundle_PUBLIC_KEY} --rekor-url ${REKOR} --show-successes --output json"
+    Then the exit status should be 0
+    Then the output should match the snapshot
+
   # Commented out as part of EC-1023. This will be enabled once the issue is resolved.
   # Scenario: many components and sources
   #   Given a key pair named "known"

--- a/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
+++ b/internal/evaluation_target/application_snapshot_image/application_snapshot_image.go
@@ -32,7 +32,6 @@ import (
 	"github.com/santhosh-tekuri/jsonschema/v5"
 	"github.com/sigstore/cosign/v3/pkg/cosign"
 	cosignOCI "github.com/sigstore/cosign/v3/pkg/oci"
-	ociremote "github.com/sigstore/cosign/v3/pkg/oci/remote"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 
@@ -123,9 +122,8 @@ func (a *ApplicationSnapshotImage) SetImageURL(url string) error {
 }
 
 func (a *ApplicationSnapshotImage) hasBundles(ctx context.Context) bool {
-	regOpts := []ociremote.Option{ociremote.WithRemoteOptions(oci.CreateRemoteOptions(ctx)...)}
-	bundles, _, err := cosign.GetBundles(ctx, a.reference, regOpts)
-	return err == nil && len(bundles) > 0
+	found, err := oci.NewClient(ctx).HasBundles(ctx, a.reference)
+	return err == nil && found
 }
 
 func (a *ApplicationSnapshotImage) FetchImageConfig(ctx context.Context) error {

--- a/internal/evaluation_target/application_snapshot_image/application_snapshot_image_test.go
+++ b/internal/evaluation_target/application_snapshot_image/application_snapshot_image_test.go
@@ -476,12 +476,13 @@ func TestValidateImageSignatureClaims(t *testing.T) {
 
 	ctx := o.WithClient(context.Background(), &c)
 
+	c.On("HasBundles", mock.Anything, ref).Return(false, nil)
 	c.On("VerifyImageSignatures", ref, mock.Anything).Return([]oci.Signature{}, false, nil)
 
 	err := a.ValidateImageSignature(ctx)
 	require.NoError(t, err)
 
-	call := c.Calls[0]
+	call := c.Calls[1]
 
 	checkOpts := call.Arguments.Get(1).(*cosign.CheckOpts)
 	assert.NotNil(t, checkOpts)
@@ -597,12 +598,13 @@ func TestValidateAttestationSignatureClaims(t *testing.T) {
 
 	ctx := o.WithClient(context.Background(), &c)
 
+	c.On("HasBundles", mock.Anything, ref).Return(false, nil)
 	c.On("VerifyImageAttestations", ref, mock.Anything).Return([]oci.Signature{}, false, nil)
 
 	err := a.ValidateAttestationSignature(ctx)
 	require.NoError(t, err)
 
-	call := c.Calls[0]
+	call := c.Calls[1]
 
 	checkOpts := call.Arguments.Get(1).(*cosign.CheckOpts)
 	assert.NotNil(t, checkOpts)
@@ -739,6 +741,7 @@ func TestValidateImageSignatureWithCertificates(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	c.On("HasBundles", mock.Anything, ref).Return(false, nil)
 	c.On("VerifyImageSignatures", ref, mock.Anything).Return([]oci.Signature{sig}, false, nil)
 
 	err = a.ValidateImageSignature(ctx)
@@ -1339,6 +1342,7 @@ func TestValidateAttestationSignature(t *testing.T) {
 			a := ApplicationSnapshotImage{reference: ref}
 
 			client := fake.FakeClient{}
+			client.On("HasBundles", mock.Anything, ref).Return(false, nil)
 			client.On("VerifyImageAttestations", ref, mock.Anything).Return(tc.signatures, false, tc.verifyErr)
 
 			ctx := o.WithClient(context.Background(), &client)

--- a/internal/image/validate_test.go
+++ b/internal/image/validate_test.go
@@ -80,6 +80,7 @@ func TestBuiltinChecks(t *testing.T) {
 			name: "simple success",
 			setup: func(c *fake.FakeClient) {
 				c.On("Head", ref).Return(&v1.Descriptor{MediaType: types.OCIManifestSchema1}, nil)
+				c.On("HasBundles", mock.Anything, refNoTag).Return(false, nil)
 				c.On("VerifyImageSignatures", refNoTag, mock.Anything).Return([]oci.Signature{validSignature}, true, nil)
 				c.On("VerifyImageAttestations", refNoTag, mock.Anything).Return([]oci.Signature{validAttestation}, true, nil)
 			},
@@ -106,6 +107,7 @@ func TestBuiltinChecks(t *testing.T) {
 			name: "no image signatures",
 			setup: func(c *fake.FakeClient) {
 				c.On("Head", ref).Return(&v1.Descriptor{MediaType: types.OCIManifestSchema1}, nil)
+				c.On("HasBundles", mock.Anything, refNoTag).Return(false, nil)
 				c.On("VerifyImageSignatures", refNoTag, mock.Anything).Return(nil, false, errors.New("no image signatures client error"))
 				c.On("VerifyImageAttestations", refNoTag, mock.Anything).Return([]oci.Signature{validAttestation}, true, nil)
 			},
@@ -122,6 +124,7 @@ func TestBuiltinChecks(t *testing.T) {
 			name: "no image attestations",
 			setup: func(c *fake.FakeClient) {
 				c.On("Head", ref).Return(&v1.Descriptor{MediaType: types.OCIManifestSchema1}, nil)
+				c.On("HasBundles", mock.Anything, refNoTag).Return(false, nil)
 				c.On("VerifyImageSignatures", refNoTag, mock.Anything).Return(validSignature, true, nil)
 				c.On("VerifyImageAttestations", refNoTag, mock.Anything).Return(nil, false, errors.New("no image attestations client error"))
 			},
@@ -325,6 +328,7 @@ func TestEvaluatorLifecycle(t *testing.T) {
 	ctx = ecoci.WithClient(ctx, &client)
 	client.On("Image", name.MustParseReference(imageRegistry+"@sha256:"+imageDigest), mock.Anything).Return(empty.Image, nil)
 	client.On("Head", ref).Return(&v1.Descriptor{MediaType: types.OCIManifestSchema1}, nil)
+	client.On("HasBundles", mock.Anything, refNoTag).Return(false, nil)
 	client.On("VerifyImageSignatures", refNoTag, mock.Anything).Return([]oci.Signature{validSignature}, true, nil)
 	client.On("VerifyImageAttestations", refNoTag, mock.Anything).Return([]oci.Signature{validAttestation}, true, nil)
 	client.On("ResolveDigest", refNoTag).Return("@sha256:"+imageDigest, nil)
@@ -367,6 +371,7 @@ func TestComponentNamePassedToEvaluator(t *testing.T) {
 	client := fake.FakeClient{}
 	client.On("Head", mock.Anything).Return(&v1.Descriptor{MediaType: types.OCIManifestSchema1}, nil)
 	client.On("Image", name.MustParseReference(imageRegistry+"@sha256:"+imageDigest), mock.Anything).Return(empty.Image, nil)
+	client.On("HasBundles", mock.Anything, refNoTag).Return(false, nil)
 	client.On("VerifyImageSignatures", refNoTag, mock.Anything).Return([]oci.Signature{validSignature}, true, nil)
 	client.On("VerifyImageAttestations", refNoTag, mock.Anything).Return([]oci.Signature{validAttestation}, true, nil)
 	client.On("ResolveDigest", refNoTag).Return("@sha256:"+imageDigest, nil)
@@ -609,6 +614,7 @@ func TestValidateImageSkipImageSigCheck(t *testing.T) {
 			// Set up minimal fake data for image to pass accessibility check
 			// and signature/attestation checks (they will fail but create results)
 			fakeClient.On("Head", ref).Return(&v1.Descriptor{MediaType: types.OCIManifestSchema1}, nil)
+			fakeClient.On("HasBundles", mock.Anything, refNoTag).Return(false, nil)
 			fakeClient.On("VerifyImageSignatures", refNoTag, mock.Anything).Return([]oci.Signature{}, false, fmt.Errorf("no signatures found"))
 			fakeClient.On("VerifyImageAttestations", refNoTag, mock.Anything).Return([]oci.Signature{}, false, fmt.Errorf("no attestations found"))
 

--- a/internal/rego/sigstore/sigstore.go
+++ b/internal/rego/sigstore/sigstore.go
@@ -131,10 +131,25 @@ func sigstoreVerifyImage(bctx rego.BuiltinContext, refTerm *ast.Term, optsTerm *
 		logger.WithField("error", err).Debug("failed to parse check opts")
 		return signatureFailedResult(fmt.Errorf("opts parameter: %w", err))
 	}
-	checkOpts.ClaimVerifier = cosign.SimpleClaimVerifier
 
-	logger.Debug("verifying image signatures")
-	signatures, _, err := ecoci.NewClient(ctx).VerifyImageSignatures(ref, checkOpts)
+	client := ecoci.NewClient(ctx)
+	useBundles, err := client.HasBundles(ctx, ref)
+	if err != nil {
+		logger.WithField("error", err).Debug("bundle detection failed, falling back to legacy path")
+		useBundles = false
+	}
+
+	var signatures []oci.Signature
+	if useBundles {
+		logger.Debug("bundles detected, using bundle verification path")
+		checkOpts.NewBundleFormat = true
+		checkOpts.ClaimVerifier = cosign.IntotoSubjectClaimVerifier
+		signatures, _, err = client.VerifyImageAttestations(ref, checkOpts)
+	} else {
+		checkOpts.ClaimVerifier = cosign.SimpleClaimVerifier
+		logger.Debug("verifying image signatures")
+		signatures, _, err = client.VerifyImageSignatures(ref, checkOpts)
+	}
 	if err != nil {
 		logger.WithField("error", err).Debug("failed to verify image signature")
 		return signatureFailedResult(fmt.Errorf("verify image signature: %w", err))

--- a/internal/rego/sigstore/sigstore.go
+++ b/internal/rego/sigstore/sigstore.go
@@ -202,15 +202,26 @@ func sigstoreVerifyAttestation(bctx rego.BuiltinContext, refTerm *ast.Term, opts
 	}
 	checkOpts.ClaimVerifier = cosign.IntotoSubjectClaimVerifier
 
+	client := ecoci.NewClient(ctx)
+	useBundles, err := client.HasBundles(ctx, ref)
+	if err != nil {
+		logger.WithField("error", err).Debug("bundle detection failed, falling back to legacy path")
+		useBundles = false
+	}
+	if useBundles {
+		logger.Debug("bundles detected, using bundle verification path")
+		checkOpts.NewBundleFormat = true
+	}
+
 	logger.Debug("verifying image attestations")
-	attestations, _, err := ecoci.NewClient(ctx).VerifyImageAttestations(ref, checkOpts)
+	attestations, _, err := client.VerifyImageAttestations(ref, checkOpts)
 	if err != nil {
 		logger.WithField("error", err).Debug("failed to verify image attestation signature")
 		return attestationFailedResult(fmt.Errorf("verify image attestation signature: %w", err))
 	}
 
 	logger.WithField("attestations_count", len(attestations)).Debug("attestation verification complete")
-	return attestationResult(attestations, nil)
+	return attestationResult(attestations, useBundles, nil)
 }
 
 func parseCheckOpts(ctx context.Context, optsTerm *ast.Term) (*cosign.CheckOpts, error) {
@@ -340,10 +351,10 @@ func signatureResult(signatures []oci.Signature, err error) (*ast.Term, error) {
 }
 
 func attestationFailedResult(err error) (*ast.Term, error) {
-	return attestationResult(nil, err)
+	return attestationResult(nil, false, err)
 }
 
-func attestationResult(attestations []oci.Signature, err error) (*ast.Term, error) {
+func attestationResult(attestations []oci.Signature, useBundles bool, err error) (*ast.Term, error) {
 	var errorTerms []*ast.Term
 	var attestationTerms []*ast.Term
 
@@ -352,9 +363,33 @@ func attestationResult(attestations []oci.Signature, err error) (*ast.Term, erro
 	}
 
 	for _, s := range attestations {
-		att, err := attestation.ProvenanceFromSignature(s)
-		if err != nil {
-			errorTerms = append(errorTerms, ast.StringTerm(fmt.Sprintf("parsing attestation: %s", err)))
+		var att attestation.Attestation
+		var parseErr error
+
+		if useBundles {
+			payload, pErr := s.Payload()
+			if pErr != nil {
+				log.WithField("error", pErr).Debug("skipping bundle entry: cannot read payload")
+				continue
+			}
+			var dsseEnvelope struct {
+				PayloadType string `json:"payloadType"`
+			}
+			if jErr := json.Unmarshal(payload, &dsseEnvelope); jErr != nil {
+				log.WithField("error", jErr).Debug("skipping bundle entry: not a valid DSSE envelope")
+				continue
+			}
+			if dsseEnvelope.PayloadType != "application/vnd.in-toto+json" {
+				log.WithField("payloadType", dsseEnvelope.PayloadType).Debug("skipping bundle entry with non-in-toto payloadType")
+				continue
+			}
+			att, parseErr = attestation.ProvenanceFromBundlePayload(s, payload)
+		} else {
+			att, parseErr = attestation.ProvenanceFromSignature(s)
+		}
+
+		if parseErr != nil {
+			errorTerms = append(errorTerms, ast.StringTerm(fmt.Sprintf("parsing attestation: %s", parseErr)))
 			continue
 		}
 

--- a/internal/rego/sigstore/sigstore_test.go
+++ b/internal/rego/sigstore/sigstore_test.go
@@ -21,6 +21,7 @@ package sigstore
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -378,6 +379,7 @@ func TestSigstoreVerifyAttestation(t *testing.T) {
 			c := fake.FakeClient{}
 			ctx := o.WithClient(context.Background(), &c)
 
+			c.On("HasBundles", mock.Anything, goodImage).Return(false, nil)
 			verifyCall := c.On(
 				"VerifyImageAttestations", goodImage, mock.Anything,
 			).Return(tt.sigs, false, tt.sigError)
@@ -393,6 +395,177 @@ func TestSigstoreVerifyAttestation(t *testing.T) {
 			require.NotNil(t, result)
 			require.Equal(t, tt.errors, result.Get(ast.StringTerm("errors")))
 			require.Equal(t, tt.success, result.Get(ast.StringTerm("success")))
+		})
+	}
+}
+
+// bundleDSSEPayload creates a DSSE envelope JSON for bundle-format attestations.
+func bundleDSSEPayload(payloadType string, statement any) []byte {
+	statementBytes, err := json.Marshal(statement)
+	if err != nil {
+		panic(err)
+	}
+	envelope := map[string]string{
+		"payloadType": payloadType,
+		"payload":     base64.StdEncoding.EncodeToString(statementBytes),
+	}
+	data, err := json.Marshal(envelope)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
+func TestSigstoreVerifyAttestationWithBundles(t *testing.T) {
+	goodImage := name.MustParseReference(
+		"registry.local/spam@sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb",
+	)
+
+	// Valid in-toto statement for bundle path
+	statement := map[string]any{
+		"_type":         "https://in-toto.io/Statement/v0.1",
+		"predicateType": "https://slsa.dev/provenance/v0.2",
+		"subject":       []any{},
+		"predicate":     map[string]any{},
+	}
+
+	validBundlePayload := bundleDSSEPayload("application/vnd.in-toto+json", statement)
+	validBundleSig, err := static.NewSignature(
+		validBundlePayload,
+		"signature",
+		static.WithLayerMediaType(types.MediaType(cosignTypes.DssePayloadType)),
+	)
+	require.NoError(t, err)
+
+	// Valid DSSE envelope structure but with corrupted base64 payload data
+	malformedBundlePayload := []byte(`{"payloadType":"application/vnd.in-toto+json","payload":"!!!bad-base64!!!"}`)
+	malformedBundleSig, err := static.NewSignature(
+		malformedBundlePayload,
+		"signature",
+		static.WithLayerMediaType(types.MediaType(cosignTypes.DssePayloadType)),
+	)
+	require.NoError(t, err)
+
+	nonInTotoPayload := bundleDSSEPayload("application/octet-stream", "binary-data")
+	nonInTotoSig, err := static.NewSignature(
+		nonInTotoPayload,
+		"signature",
+		static.WithLayerMediaType(types.MediaType(cosignTypes.DssePayloadType)),
+	)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name    string
+		success *ast.Term
+		errors  *ast.Term
+		sigs    []oci.Signature
+	}{
+		{
+			name:    "bundle attestation verification succeeds",
+			success: ast.BooleanTerm(true),
+			errors:  ast.ArrayTerm(),
+			sigs:    []oci.Signature{validBundleSig},
+		},
+		{
+			name:    "malformed bundle payload produces parsing error",
+			success: ast.BooleanTerm(false),
+			errors: ast.ArrayTerm(
+				ast.StringTerm("parsing attestation: malformed attestation data: illegal base64 data at input byte 0"),
+			),
+			sigs: []oci.Signature{malformedBundleSig},
+		},
+		{
+			name:    "non-in-toto payload type is skipped",
+			success: ast.BooleanTerm(true),
+			errors:  ast.ArrayTerm(),
+			sigs:    []oci.Signature{nonInTotoSig},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			utils.SetTestRekorPublicKey(t)
+			utils.SetTestFulcioRoots(t)
+			utils.SetTestCTLogPublicKey(t)
+
+			c := fake.FakeClient{}
+			ctx := o.WithClient(context.Background(), &c)
+
+			c.On("HasBundles", mock.Anything, goodImage).Return(true, nil)
+			c.On(
+				"VerifyImageAttestations", goodImage, mock.Anything,
+			).Return(tt.sigs, false, nil)
+
+			bctx := rego.BuiltinContext{Context: ctx}
+
+			result, err := sigstoreVerifyAttestation(
+				bctx,
+				ast.StringTerm(goodImage.String()),
+				options{ignoreRekor: true, publicKey: utils.TestPublicKey}.toTerm(),
+			)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, tt.errors, result.Get(ast.StringTerm("errors")))
+			require.Equal(t, tt.success, result.Get(ast.StringTerm("success")))
+		})
+	}
+}
+
+func TestSigstoreVerifyAttestationBundleFallback(t *testing.T) {
+	goodImage := name.MustParseReference(
+		"registry.local/spam@sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb",
+	)
+
+	// Legacy-format signature (same as existing tests)
+	goodSig, err := static.NewSignature(
+		[]byte(fmt.Sprintf(`{"payload": "%s"}`, base64.StdEncoding.EncodeToString([]byte("{}")))),
+		"signature",
+		static.WithLayerMediaType(types.MediaType(cosignTypes.DssePayloadType)),
+	)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name       string
+		hasBundles bool
+		bundleErr  error
+	}{
+		{
+			name:       "HasBundles returns error falls back to legacy",
+			hasBundles: false,
+			bundleErr:  errors.New("registry error"),
+		},
+		{
+			name:       "HasBundles returns false uses legacy path",
+			hasBundles: false,
+			bundleErr:  nil,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			utils.SetTestRekorPublicKey(t)
+			utils.SetTestFulcioRoots(t)
+			utils.SetTestCTLogPublicKey(t)
+
+			c := fake.FakeClient{}
+			ctx := o.WithClient(context.Background(), &c)
+
+			c.On("HasBundles", mock.Anything, goodImage).Return(tt.hasBundles, tt.bundleErr)
+			c.On(
+				"VerifyImageAttestations", goodImage, mock.Anything,
+			).Return([]oci.Signature{goodSig}, false, nil)
+
+			bctx := rego.BuiltinContext{Context: ctx}
+
+			result, err := sigstoreVerifyAttestation(
+				bctx,
+				ast.StringTerm(goodImage.String()),
+				options{ignoreRekor: true, publicKey: utils.TestPublicKey}.toTerm(),
+			)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, ast.BooleanTerm(true), result.Get(ast.StringTerm("success")))
+			require.Equal(t, ast.ArrayTerm(), result.Get(ast.StringTerm("errors")))
 		})
 	}
 }

--- a/internal/rego/sigstore/sigstore_test.go
+++ b/internal/rego/sigstore/sigstore_test.go
@@ -190,6 +190,7 @@ func TestSigstoreVerifyImage(t *testing.T) {
 			)
 			require.NoError(t, err)
 
+			c.On("HasBundles", mock.Anything, goodImage).Return(false, nil)
 			verifyCall := c.On(
 				"VerifyImageSignatures", goodImage, mock.Anything,
 			).Return([]oci.Signature{sig}, false, tt.sigError)
@@ -558,6 +559,120 @@ func TestSigstoreVerifyAttestationBundleFallback(t *testing.T) {
 			bctx := rego.BuiltinContext{Context: ctx}
 
 			result, err := sigstoreVerifyAttestation(
+				bctx,
+				ast.StringTerm(goodImage.String()),
+				options{ignoreRekor: true, publicKey: utils.TestPublicKey}.toTerm(),
+			)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, ast.BooleanTerm(true), result.Get(ast.StringTerm("success")))
+			require.Equal(t, ast.ArrayTerm(), result.Get(ast.StringTerm("errors")))
+		})
+	}
+}
+
+func TestSigstoreVerifyImageWithBundles(t *testing.T) {
+	goodImage := name.MustParseReference(
+		"registry.local/spam@sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb",
+	)
+
+	sig, err := static.NewSignature(
+		[]byte(`image`),
+		"signature",
+		static.WithLayerMediaType(types.MediaType(cosignTypes.DssePayloadType)),
+	)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name    string
+		success *ast.Term
+		errors  *ast.Term
+	}{
+		{
+			name:    "bundle-format image verification succeeds",
+			success: ast.BooleanTerm(true),
+			errors:  ast.ArrayTerm(),
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			utils.SetTestRekorPublicKey(t)
+			utils.SetTestFulcioRoots(t)
+			utils.SetTestCTLogPublicKey(t)
+
+			c := fake.FakeClient{}
+			ctx := o.WithClient(context.Background(), &c)
+
+			c.On("HasBundles", mock.Anything, goodImage).Return(true, nil)
+			c.On(
+				"VerifyImageAttestations", goodImage, mock.Anything,
+			).Return([]oci.Signature{sig}, false, nil).Run(func(args mock.Arguments) {
+				checkOpts := args.Get(1).(*cosign.CheckOpts)
+				require.True(t, checkOpts.NewBundleFormat)
+			})
+
+			bctx := rego.BuiltinContext{Context: ctx}
+
+			result, err := sigstoreVerifyImage(
+				bctx,
+				ast.StringTerm(goodImage.String()),
+				options{ignoreRekor: true, publicKey: utils.TestPublicKey}.toTerm(),
+			)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, tt.errors, result.Get(ast.StringTerm("errors")))
+			require.Equal(t, tt.success, result.Get(ast.StringTerm("success")))
+		})
+	}
+}
+
+func TestSigstoreVerifyImageBundleFallback(t *testing.T) {
+	goodImage := name.MustParseReference(
+		"registry.local/spam@sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb",
+	)
+
+	sig, err := static.NewSignature(
+		[]byte(`image`),
+		"signature",
+		static.WithLayerMediaType(types.MediaType(cosignTypes.DssePayloadType)),
+	)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name       string
+		hasBundles bool
+		bundleErr  error
+	}{
+		{
+			name:       "HasBundles returns error falls back to legacy",
+			hasBundles: false,
+			bundleErr:  errors.New("registry error"),
+		},
+		{
+			name:       "HasBundles returns false uses legacy path",
+			hasBundles: false,
+			bundleErr:  nil,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			utils.SetTestRekorPublicKey(t)
+			utils.SetTestFulcioRoots(t)
+			utils.SetTestCTLogPublicKey(t)
+
+			c := fake.FakeClient{}
+			ctx := o.WithClient(context.Background(), &c)
+
+			c.On("HasBundles", mock.Anything, goodImage).Return(tt.hasBundles, tt.bundleErr)
+			c.On(
+				"VerifyImageSignatures", goodImage, mock.Anything,
+			).Return([]oci.Signature{sig}, false, nil)
+
+			bctx := rego.BuiltinContext{Context: ctx}
+
+			result, err := sigstoreVerifyImage(
 				bctx,
 				ast.StringTerm(goodImage.String()),
 				options{ignoreRekor: true, publicKey: utils.TestPublicKey}.toTerm(),

--- a/internal/rego/sigstore/sigstore_test.go
+++ b/internal/rego/sigstore/sigstore_test.go
@@ -495,7 +495,10 @@ func TestSigstoreVerifyAttestationWithBundles(t *testing.T) {
 			c.On("HasBundles", mock.Anything, goodImage).Return(true, nil)
 			c.On(
 				"VerifyImageAttestations", goodImage, mock.Anything,
-			).Return(tt.sigs, false, nil)
+			).Return(tt.sigs, false, nil).Run(func(args mock.Arguments) {
+				checkOpts := args.Get(1).(*cosign.CheckOpts)
+				require.True(t, checkOpts.NewBundleFormat)
+			})
 
 			bctx := rego.BuiltinContext{Context: ctx}
 

--- a/internal/utils/oci/client.go
+++ b/internal/utils/oci/client.go
@@ -76,6 +76,7 @@ func CreateRemoteOptions(ctx context.Context) []remote.Option {
 type Client interface {
 	VerifyImageSignatures(name.Reference, *cosign.CheckOpts) ([]oci.Signature, bool, error)
 	VerifyImageAttestations(name.Reference, *cosign.CheckOpts) ([]oci.Signature, bool, error)
+	HasBundles(context.Context, name.Reference) (bool, error)
 	Head(name.Reference) (*v1.Descriptor, error)
 	ResolveDigest(name.Reference) (string, error)
 	Image(name.Reference) (v1.Image, error)
@@ -127,6 +128,15 @@ func (c *defaultClient) VerifyImageAttestations(ref name.Reference, opts *cosign
 
 	opts.RegistryClientOpts = append(opts.RegistryClientOpts, ociremote.WithRemoteOptions(c.opts...))
 	return cosign.VerifyImageAttestations(c.ctx, ref, opts)
+}
+
+func (c *defaultClient) HasBundles(ctx context.Context, ref name.Reference) (bool, error) {
+	regOpts := []ociremote.Option{ociremote.WithRemoteOptions(c.opts...)}
+	bundles, _, err := cosign.GetBundles(ctx, ref, regOpts)
+	if err != nil {
+		return false, err
+	}
+	return len(bundles) > 0, nil
 }
 
 func (c *defaultClient) Head(ref name.Reference) (*v1.Descriptor, error) {

--- a/internal/utils/oci/fake/client.go
+++ b/internal/utils/oci/fake/client.go
@@ -101,6 +101,11 @@ func (m *FakeClient) VerifyImageAttestations(ref name.Reference, opts *cosign.Ch
 	return sigs, args.Bool(1), args.Error(2)
 }
 
+func (m *FakeClient) HasBundles(ctx context.Context, ref name.Reference) (bool, error) {
+	args := m.Called(ctx, ref)
+	return args.Bool(0), args.Error(1)
+}
+
 func (m *FakeClient) Head(ref name.Reference) (*v1.Descriptor, error) {
 	args := m.Called(ref)
 	var desc *v1.Descriptor


### PR DESCRIPTION
## Summary\n\n- Adds `HasBundles(ctx, ref)` to `oci.Client` interface, wrapping `cosign.GetBundles()` for testable bundle detection\n- Auto-detects Sigstore bundles (OCI referrers) in `ec.sigstore.verify_attestation` and `ec.sigstore.verify_image` Rego builtins; when bundles are present, uses `NewBundleFormat=true`, `ProvenanceFromBundlePayload()`, and `IntotoSubjectClaimVerifier`; falls back to legacy `.att` tag path when no bundles exist\n- Refactors `ApplicationSnapshotImage.hasBundles()` to delegate to the new `oci.Client.HasBundles()` method, eliminating duplication\n- Adds acceptance test scenario for bundle-format attestation verification\n\nRef: https://issues.redhat.com/browse/EC-1700